### PR TITLE
ARC-102-Task Activity Page No Longer Shows Correct Links

### DIFF
--- a/templates/api-gw-lambda.yaml
+++ b/templates/api-gw-lambda.yaml
@@ -68,5 +68,11 @@ spec:
         catalogInfoPath: "/catalog-info.yaml"
 
   output:
+    links:
+      - title: Repository
+        url: ${{ steps.publish.output.remoteUrl }}
+      - title: Open in catalog
+        icon: catalog
+        entityRef: ${{ steps.register.output.entityRef }}
     remoteUrl: ${{ steps.publish.output.remoteUrl }}
     entityRef: ${{ steps.register.output.entityRef }}


### PR DESCRIPTION
Task Activity Page No Longer Shows Correct Links

[ARC-102](https://github.com/sourcefuse/backstage/issues/102)

## Description
Following the branding, the Task Activity page is missing the links to the Backstage catalog and GitHub for the newly created component.
The Task Activity page no longer shows the links to the Backstage catalog info and GitHub repo.

To resolve above issue, we should add links in output for each template. This is the PR where I updated api-gw-lambda.yaml file to add catalog and repo links in output. We need to make same changes in other templates as well.
![image](https://github.com/sourcefuse/typescript-lambda-boilerplate/assets/109595269/137df20d-66c7-4774-a759-81f414795ac4)

Fixes # (issue)
[ARC-102](https://github.com/sourcefuse/backstage/issues/102)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Intermediate change (work in progress)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## Checklist:

- [X] Performed a self-review of my own code
- [X] npm test passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the style guide
- [ ] API Documentation in code was updated
- [ ] Any dependent changes have been merged and published in downstream modules


[ARC-116]: https://sourcefuse.atlassian.net/browse/ARC-116?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ARC-116]: https://sourcefuse.atlassian.net/browse/ARC-116?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[ARC-102]: https://sourcefuse.atlassian.net/browse/ARC-102?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ARC-102]: https://sourcefuse.atlassian.net/browse/ARC-102?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ